### PR TITLE
Quick typo fix for php version

### DIFF
--- a/source/production.md
+++ b/source/production.md
@@ -16,7 +16,7 @@ Be sure to keep any of your production environment configuration variables up to
 
 It is useful to store production-specific configuration in `.env.production.example`, such as defining your cache and session drivers as `redis` instead of `file` or that debug should be disabled.
 
-The following deployment script should be used on a PHP 7.1 host, and can be executed once the application repository has been installed by clicking on the *Deploy Now* button.
+The following deployment script should be used on a PHP 7.2 host, and can be executed once the application repository has been installed by clicking on the *Deploy Now* button.
 
 ```
 cd /home/forge/{{ site_name }}


### PR DESCRIPTION
You updated the deployment script to php 7.2, but still mentioning php 7.1 in the text above.